### PR TITLE
Fix flaky declared fields method

### DIFF
--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -46,9 +46,7 @@ public final class GraphAdapterBuilderTest {
         .registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
-    assertEquals("{'0x1':{'name':'ROCK','beats':'0x2'}," +
-        "'0x2':{'name':'SCISSORS','beats':'0x3'}," +
-        "'0x3':{'name':'PAPER','beats':'0x1'}}",
+    assertEquals("{'0x1':{'beats':'0x2','name':'ROCK'},'0x2':{'beats':'0x3','name':'SCISSORS'},'0x3':{'beats':'0x1','name':'PAPER'}}",
         gson.toJson(rock).replace('"', '\''));
   }
 
@@ -140,9 +138,7 @@ public final class GraphAdapterBuilderTest {
         .registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
-    assertEquals("{'0x1':{'name':'Google','employees':['0x2','0x3']},"
-        + "'0x2':{'name':'Jesse','company':'0x1'},"
-        + "'0x3':{'name':'Joel','company':'0x1'}}",
+    assertEquals("{'0x1':{'employees':['0x2','0x3'],'name':'Google'},'0x2':{'company':'0x1','name':'Jesse'},'0x3':{'company':'0x1','name':'Joel'}}",
         gson.toJson(google).replace('"', '\''));
   }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -51,6 +51,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -263,7 +264,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     Class<?> originalRaw = raw;
     while (raw != Object.class) {
       Field[] fields = raw.getDeclaredFields();
-
+      Arrays.sort(fields, new Comparator<Field>() {
+            @Override
+            public int compare(Field f1, Field f2) {
+                return f1.getName().compareTo(f2.getName());
+            }
+        });
       // For inherited fields, check if access to their declaring class is allowed
       if (raw != originalRaw && fields.length > 0) {
         FilterResult filterResult = ReflectionAccessFilterHelper.getFilterResult(reflectionFilters, raw);

--- a/gson/src/test/java/com/google/gson/MixedStreamTest.java
+++ b/gson/src/test/java/com/google/gson/MixedStreamTest.java
@@ -37,16 +37,16 @@ public final class MixedStreamTest {
   private static final Car RED_MIATA = new Car("miata", 0xFF0000);
   private static final String CARS_JSON = "[\n"
       + "  {\n"
-      + "    \"name\": \"mustang\",\n"
-      + "    \"color\": 255\n"
+      + "    \"color\": 255,\n"
+      + "    \"name\": \"mustang\"\n"
       + "  },\n"
       + "  {\n"
-      + "    \"name\": \"bmw\",\n"
-      + "    \"color\": 0\n"
+      + "    \"color\": 0,\n"
+      + "    \"name\": \"bmw\"\n"
       + "  },\n"
       + "  {\n"
-      + "    \"name\": \"miata\",\n"
-      + "    \"color\": 16711680\n"
+      + "    \"color\": 16711680,\n"
+      + "    \"name\": \"miata\"\n"
       + "  }\n"
       + "]";
 

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -127,9 +127,9 @@ public class TestTypes {
     public String getExpectedJson() {
       StringBuilder sb = new StringBuilder();
       sb.append("{");
-      sb.append("\"longValue\":").append(longValue).append(",");
-      sb.append("\"intValue\":").append(intValue).append(",");
       sb.append("\"booleanValue\":").append(booleanValue).append(",");
+      sb.append("\"intValue\":").append(intValue).append(",");
+      sb.append("\"longValue\":").append(longValue).append(",");
       sb.append("\"stringValue\":\"").append(stringValue).append("\"");
       sb.append("}");
       return sb.toString();
@@ -182,9 +182,9 @@ public class TestTypes {
     public String getExpectedJson() {
       StringBuilder sb = new StringBuilder();
       sb.append("{");
-      sb.append("\"longValue\":").append(longValue).append(",");
+      sb.append("\"booleanValue\":").append(booleanValue).append(",");
       sb.append("\"intValue\":").append(intValue).append(",");
-      sb.append("\"booleanValue\":").append(booleanValue);
+      sb.append("\"longValue\":").append(longValue);
       sb.append("}");
       return sb.toString();
     }

--- a/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java
@@ -35,54 +35,42 @@ public final class FieldNamingTest {
   public void testIdentity() {
     Gson gson = getGsonWithNamingPolicy(IDENTITY);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'lowerCamel':1,'UpperCamel':2,'_lowerCamelLeadingUnderscore':3," +
-            "'_UpperCamelLeadingUnderscore':4,'lower_words':5,'UPPER_WORDS':6," +
-            "'annotatedName':7,'lowerId':8,'_9':9}");
+        .isEqualTo("{'UPPER_WORDS':6,'UpperCamel':2,'_9':9,'_UpperCamelLeadingUnderscore':4,'_lowerCamelLeadingUnderscore':3,'annotatedName':7,'lowerCamel':1,'lowerId':8,'lower_words':5}");
   }
 
   @Test
   public void testUpperCamelCase() {
     Gson gson = getGsonWithNamingPolicy(UPPER_CAMEL_CASE);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'LowerCamel':1,'UpperCamel':2,'_LowerCamelLeadingUnderscore':3," +
-            "'_UpperCamelLeadingUnderscore':4,'Lower_words':5,'UPPER_WORDS':6," +
-            "'annotatedName':7,'LowerId':8,'_9':9}");
+        .isEqualTo("{'UPPER_WORDS':6,'UpperCamel':2,'_9':9,'_UpperCamelLeadingUnderscore':4,'_LowerCamelLeadingUnderscore':3,'annotatedName':7,'LowerCamel':1,'LowerId':8,'Lower_words':5}");
   }
 
   @Test
   public void testUpperCamelCaseWithSpaces() {
     Gson gson = getGsonWithNamingPolicy(UPPER_CAMEL_CASE_WITH_SPACES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'Lower Camel':1,'Upper Camel':2,'_Lower Camel Leading Underscore':3," +
-            "'_ Upper Camel Leading Underscore':4,'Lower_words':5,'U P P E R_ W O R D S':6," +
-            "'annotatedName':7,'Lower Id':8,'_9':9}");
+        .isEqualTo("{'U P P E R_ W O R D S':6,'Upper Camel':2,'_9':9,'_ Upper Camel Leading Underscore':4,'_Lower Camel Leading Underscore':3,'annotatedName':7,'Lower Camel':1,'Lower Id':8,'Lower_words':5}");
   }
 
   @Test
   public void testUpperCaseWithUnderscores() {
     Gson gson = getGsonWithNamingPolicy(UPPER_CASE_WITH_UNDERSCORES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'LOWER_CAMEL':1,'UPPER_CAMEL':2,'_LOWER_CAMEL_LEADING_UNDERSCORE':3," +
-            "'__UPPER_CAMEL_LEADING_UNDERSCORE':4,'LOWER_WORDS':5,'U_P_P_E_R__W_O_R_D_S':6," +
-            "'annotatedName':7,'LOWER_ID':8,'_9':9}");
+        .isEqualTo("{'U_P_P_E_R__W_O_R_D_S':6,'UPPER_CAMEL':2,'_9':9,'__UPPER_CAMEL_LEADING_UNDERSCORE':4,'_LOWER_CAMEL_LEADING_UNDERSCORE':3,'annotatedName':7,'LOWER_CAMEL':1,'LOWER_ID':8,'LOWER_WORDS':5}");
   }
 
   @Test
   public void testLowerCaseWithUnderscores() {
     Gson gson = getGsonWithNamingPolicy(LOWER_CASE_WITH_UNDERSCORES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'lower_camel':1,'upper_camel':2,'_lower_camel_leading_underscore':3," +
-            "'__upper_camel_leading_underscore':4,'lower_words':5,'u_p_p_e_r__w_o_r_d_s':6," +
-            "'annotatedName':7,'lower_id':8,'_9':9}");
+        .isEqualTo("{'u_p_p_e_r__w_o_r_d_s':6,'upper_camel':2,'_9':9,'__upper_camel_leading_underscore':4,'_lower_camel_leading_underscore':3,'annotatedName':7,'lower_camel':1,'lower_id':8,'lower_words':5}");
   }
-
+  
   @Test
   public void testLowerCaseWithDashes() {
     Gson gson = getGsonWithNamingPolicy(LOWER_CASE_WITH_DASHES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'lower-camel':1,'upper-camel':2,'_lower-camel-leading-underscore':3," +
-            "'_-upper-camel-leading-underscore':4,'lower_words':5,'u-p-p-e-r_-w-o-r-d-s':6," +
-            "'annotatedName':7,'lower-id':8,'_9':9}");
+        .isEqualTo("{'u-p-p-e-r_-w-o-r-d-s':6,'upper-camel':2,'_9':9,'_-upper-camel-leading-underscore':4,'_lower-camel-leading-underscore':3,'annotatedName':7,'lower-camel':1,'lower-id':8,'lower_words':5}");
   }
 
   private Gson getGsonWithNamingPolicy(FieldNamingPolicy fieldNamingPolicy){

--- a/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
@@ -64,10 +64,7 @@ public class InheritanceTest {
 
   @Test
   public void testSubClassDeserialization() {
-    String json = "{\"value\":5,\"primitive1\":{\"longValue\":10,\"intValue\":20,"
-        + "\"booleanValue\":false,\"stringValue\":\"stringValue\"},\"primitive2\":"
-        + "{\"longValue\":30,\"intValue\":40,\"booleanValue\":true,"
-        + "\"stringValue\":\"stringValue\"}}";
+    String json = "{\"value\":5,\"primitive1\":{\"booleanValue\":false,\"intValue\":20,\"longValue\":10,\"stringValue\":\"stringValue\"},\"primitive2\":{\"booleanValue\":true,\"intValue\":40,\"longValue\":30,\"stringValue\":\"stringValue\"}}";
     SubTypeOfNested target = gson.fromJson(json, SubTypeOfNested.class);
     assertThat(target.getExpectedJson()).isEqualTo(json);
   }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -218,9 +218,7 @@ public class ObjectTest {
 
   @Test
   public void testNestedDeserialization() {
-    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false,"
-        + "\"stringValue\":\"stringValue\"},\"primitive2\":{\"longValue\":30,\"intValue\":40,"
-        + "\"booleanValue\":true,\"stringValue\":\"stringValue\"}}";
+    String json = "{\"primitive1\":{\"booleanValue\":false,\"intValue\":20,\"longValue\":10,\"stringValue\":\"stringValue\"},\"primitive2\":{\"booleanValue\":true,\"intValue\":40,\"longValue\":30,\"stringValue\":\"stringValue\"}}";
     Nested target = gson.fromJson(json, Nested.class);
     assertThat(target.getExpectedJson()).isEqualTo(json);
   }
@@ -260,8 +258,7 @@ public class ObjectTest {
 
   @Test
   public void testNullFieldsDeserialization() {
-    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false"
-        + ",\"stringValue\":\"stringValue\"}}";
+    String json = "{\"primitive1\":{\"booleanValue\":false,\"intValue\":20,\"longValue\":10,\"stringValue\":\"stringValue\"}}";
     Nested target = gson.fromJson(json, Nested.class);
     assertThat(target.getExpectedJson()).isEqualTo(json);
   }


### PR DESCRIPTION
### Purpose
This PR fixes the following tests detected as flaky
```
com.google.gson.functional.CustomTypeAdaptersTest.testCustomNestedSerializers
com.google.gson.functional.EnumTest.testClassWithEnumFieldSerialization
com.google.gson.functional.FieldNamingTest.testIdentity
com.google.gson.functional.FieldNamingTest.testLowerCaseWithDashes
com.google.gson.functional.FieldNamingTest.testLowerCaseWithUnderscores
com.google.gson.functional.FieldNamingTest.testUpperCamelCase
com.google.gson.functional.FieldNamingTest.testUpperCamelCaseWithSpaces
com.google.gson.functional.FieldNamingTest.testUpperCaseWithUnderscores
com.google.gson.functional.JsonAdapterAnnotationOnFieldsTest.testExcludeDeserializePrecedence
com.google.gson.functional.JsonAdapterSerializerDeserializerTest.testJsonSerializerDeserializerBasedJsonAdapterOnFields
com.google.gson.functional.MapAsArrayTypeAdapterTest.testMapWithTypeVariableSerialization
com.google.gson.functional.MapAsArrayTypeAdapterTest.testMultipleEnableComplexKeyRegistrationHasNoEffect
com.google.gson.functional.MapAsArrayTypeAdapterTest.testSerializeComplexMapWithTypeAdapter
com.google.gson.functional.MapTest.testInterfaceTypeMap
com.google.gson.functional.MapTest.testInterfaceTypeMapWithSerializer
com.google.gson.functional.NamingPolicyTest.testGsonDuplicateNameDueToBadNamingPolicy
com.google.gson.functional.NamingPolicyTest.testGsonWithSerializedNameFieldNamingPolicySerialization
com.google.gson.functional.ObjectTest.testArrayOfArraysSerialization
com.google.gson.functional.ObjectTest.testArrayOfObjectsSerialization
com.google.gson.functional.ObjectTest.testBagOfPrimitivesSerialization
com.google.gson.functional.ObjectTest.testBagOfPrimitiveWrappersSerialization
com.google.gson.functional.ObjectTest.testNestedSerialization
com.google.gson.functional.ObjectTest.testNullFieldsSerialization
com.google.gson.functional.PrettyPrintingTest.testEmptyMapField
com.google.gson.functional.ReadersWritersTest.testWriterForSerialization
com.google.gson.functional.ReflectionAccessFilterTest.testBlockInaccessibleJavaExtendingJdkClass
com.google.gson.functional.SerializedNameTest.testFirstNameIsChosenForSerialization
com.google.gson.functional.StreamingTypeAdaptersTest.testSerializeNullObject
com.google.gson.functional.StreamingTypeAdaptersTest.testSerializeRecursive
com.google.gson.functional.VersioningTest.testVersionedClassesSerialization
com.google.gson.functional.VersioningTest.testVersionedGsonWithUnversionedClassesSerialization
com.google.gson.graph.GraphAdapterBuilderTest.testSerialization
com.google.gson.graph.GraphAdapterBuilderTest.testSerializationWithMultipleTypes
com.google.gson.MixedStreamTest.testWriteMixedStreamed
com.google.gson.ObjectTypeAdapterTest.testSerialize
com.google.gson.typeadapters.PostConstructAdapterFactoryTest.testList
```

### Description
This [line](    https://github.com/google/gson/blob/5bfa7fc5acdde666571006e27bebfeb75444308b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java#L304) of code does not return the fields in a consistent order causing the tests to be flaky. The fix sorts these fields using the field names as a comparator.

**Reason:**
The `gson.toJson()` internally calls `com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields` which makes a call to `getDeclaredFields`

https://github.com/google/gson/blob/e685705b2bf3ae174958612a185bd231c0e0c5d9/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java#L265

And according to this [stackoverlow discussion](https://stackoverflow.com/questions/18325666/does-class-getdeclaredfields-return-members-in-a-consistent-order), `getDeclaredFields` in Java 8 does not return elements in a consistent order.

### Reproduction of error

**Command to reproduce the failure:**
```mvn -pl gson edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<testclass>#<testname>```

**Example - test case FieldNamingTest.testLowerCaseWithUnderscores**
```
mvn -pl gson edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.gson.functional.FieldNamingTest#testLowerCaseWithUnderscores
```

 **Error Message:**
```
[ERROR] com.google.gson.functional.FieldNamingTest.testLowerCaseWithUnderscores -- Time elapsed: 0.003 s <<< FAILURE!
value of: replace(...)
expected: {'lower_camel':1,'upper_camel':2,'_lower_camel_leading_underscore':3,'__upper_camel_leading_underscore':4,'lower_words':5,'u_p_p_e_r__w_o_r_d_s':6,'annotatedName':7,'lower_id':8,'_9':9}
but was : {'annotatedName':7,'__upper_camel_leading_underscore':4,'lower_id':8,'upper_camel':2,'u_p_p_e_r__w_o_r_d_s':6,'lower_camel':1,'_9':9,'lower_words':5,'_lower_camel_leading_underscore':3}
	at com.google.gson.functional.FieldNamingTest.testLowerCaseWithUnderscores(FieldNamingTest.java:74)
```
